### PR TITLE
fix TypeError when accessing TetGen.mesh property

### DIFF
--- a/.ci/azure-publish-dist.yml
+++ b/.ci/azure-publish-dist.yml
@@ -14,13 +14,3 @@ steps:
     TWINE_USERNAME: $(twine.username)
     TWINE_PASSWORD: $(twine.password)
     TWINE_REPOSITORY_URL: "https://upload.pypi.org/legacy/"
-
-- script: |
-    pip install twine wheel
-    twine upload dist/*.whl --skip-existing
-  displayName: 'Upload to Testing PyPi'
-  condition: not(contains(variables['Build.SourceBranch'], 'refs/tags/'))
-  env:
-    TWINE_USERNAME: $(twine.username)
-    TWINE_PASSWORD: $(twine.password)
-    TWINE_REPOSITORY_URL: "https://test.pypi.org/legacy/"

--- a/tetgen/_version.py
+++ b/tetgen/_version.py
@@ -1,7 +1,7 @@
 """ tetgen version """
 
 # major, minor, patch, -extra
-version_info = 0, 5, 0
+version_info = 0, 5, 1
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/tetgen/pytetgen.py
+++ b/tetgen/pytetgen.py
@@ -155,7 +155,7 @@ class TetGen(object):
     @property
     def mesh(self):
         """Return the surface mesh"""
-        triangles = np.empty((self.f.shape[0], 4))
+        triangles = np.empty((self.f.shape[0], 4), dtype='int')
         triangles[:, -3:] = self.f
         triangles[:, 0] = 3
         return pv.PolyData(self.v, triangles, deep=False)


### PR DESCRIPTION
I'm using numpy 1.18.5 on windows and I was getting `TypeError: Indices must be either a mask or an integer array-like` when trying to access `TetGen.mesh`. Specifying the dtype of the triangles array in that method as int fixes it.