### PR TITLE
Fix python version in macOS build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,7 @@ jobs:
       Python37:
         python.version: '3.7'
       Python38:
-        python.version: '3.7'
+        python.version: '3.8'
   pool:
     vmImage: 'macOS-10.14'
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,8 +15,6 @@ jobs:
 - job: Linux
   strategy:
     matrix:
-      Python35:
-        python.version: '3.5'
       Python36:
         python.version: '3.6'
       Python37:
@@ -73,8 +71,6 @@ jobs:
     python.architecture: 'x64'
   strategy:
     matrix:
-      Python35:
-        python.version: '3.5'
       Python36:
         python.version: '3.6'
       Python37:


### PR DESCRIPTION
This PR fixes the version number for the macOS build for Python 3.8 in the azure pipelines.

Closes #25 