### PR TITLE
remove direct vtk usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+# Simple makefile to simplify repetitive build env management tasks under posix
+
+CODESPELL_DIRS ?= ./
+CODESPELL_SKIP ?= "*.pyc,*.txt,*.gif,*.png,*.jpg,*.ply,*.vtk,*.vti,*.js,*.html,*.doctree,*.ttf,*.woff,*.woff2,*.eot,*.mp4,*.inv,*.pickle,*.ipynb,flycheck*,./.git/*,./.hypothesis/*,*.yml,./doc/_build/*,./doc/images/*,./dist/*,*~,.hypothesis*,./doc/examples/*,*.mypy_cache/*,*cover,./tests/tinypages/_build/*,*/_autosummary/*,*.cxx,*.cpp,*.h,*.egg-info/*"
+
+stylecheck: codespell pydocstyle
+
+codespell:
+	@echo "Running codespell"
+	@codespell $(CODESPELL_DIRS) -S $(CODESPELL_SKIP)
+# -I $(CODESPELL_IGNORE)
+
+pydocstyle:
+	@echo "Running pydocstyle"
+	@pydocstyle tetgen
+

--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ the mesh quality.
     plotter.add_mesh(subgrid, 'lightgrey', lighting=True, show_edges=True)
     plotter.add_mesh(sphere, 'r', 'wireframe')
     plotter.add_legend([[' Input Mesh ', 'r'],
-                        [' Tesselated Mesh ', 'black']])
+                        [' Tessellated Mesh ', 'black']])
     plotter.show()
 
 .. image:: https://github.com/pyvista/tetgen/raw/master/doc/images/sphere_subgrid.png

--- a/examples/sphere.py
+++ b/examples/sphere.py
@@ -36,7 +36,7 @@ plotter = pv.Plotter()
 plotter.add_mesh(subgrid, 'lightgrey', lighting=True, show_edges=True)
 plotter.add_mesh(sphere, 'r', 'wireframe')
 plotter.add_legend([[' Input Mesh ', 'r'],
-                    [' Tesselated Mesh ', 'black']])
+                    [' Tessellated Mesh ', 'black']])
 plotter.show()
 
 ###############################################################################

--- a/examples/super_toroid.py
+++ b/examples/super_toroid.py
@@ -33,7 +33,7 @@ plotter = pv.Plotter()
 plotter.add_mesh(subgrid, color='lightgrey', lighting=True, show_edges=True)
 plotter.add_mesh(toroid, color='r', style='wireframe')
 plotter.add_legend([[' Input Mesh ', 'r'],
-                    [' Tesselated Mesh ', 'black']])
+                    [' Tessellated Mesh ', 'black']])
 plotter.show()
 
 ###############################################################################

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
                            define_macros=[('TETLIBRARY', None)]),
                    ],
     keywords='TetGen',
-    install_requires=['numpy>1.9.3',
-                      'pyvista>=0.23.0'],
+    install_requires=['numpy>1.16.0',
+                      'pyvista>=0.31.0'],
     setup_requires=setup_requires,
 )

--- a/tests/test_tetgen.py
+++ b/tests/test_tetgen.py
@@ -4,10 +4,6 @@ import pyvista as pv
 import tetgen
 import numpy as np
 
-try:
-    __file__
-except:  # local testing
-    __file__ = '/home/alex/afrl/python/source/tetgen/tests/test_tetgen.py'
 
 path = os.path.dirname(os.path.abspath(__file__))
 
@@ -94,7 +90,7 @@ def functional_tet_example():
     plotter.add_mesh(subgrid, 'lightgrey', lighting=True)
     plotter.add_mesh(grid, 'r', 'wireframe')
     plotter.add_legend([[' Input Mesh ', 'r'],
-                       [' Tesselated Mesh ', 'black']])
+                       [' Tessellated Mesh ', 'black']])
     plotter.show()
 
     plotter = pv.Plotter()

--- a/tetgen/cython/tetgen/_tetgen.pyx
+++ b/tetgen/cython/tetgen/_tetgen.pyx
@@ -400,7 +400,7 @@ def Tetrahedralize(v, f, switches='',
         tetrahedralize(&behavior.c_behavior, &tetgenio_in.c_tetio, 
                        &tetgenio_out.c_tetio)
 
-    # Returns verticies and tetrahedrals of new mesh
+    # Returns vertices and tetrahedrals of new mesh
     nodes = tetgenio_out.ReturnNodes()
     tets = tetgenio_out.ReturnTetrahedrals(order)
 

--- a/tetgen/pytetgen.py
+++ b/tetgen/pytetgen.py
@@ -5,7 +5,7 @@ import ctypes
 
 import numpy as np
 import pyvista as pv
-import vtk
+from pyvista._vtk import VTK9
 
 from tetgen import _tetgen
 
@@ -13,14 +13,11 @@ LOG = logging.getLogger(__name__)
 LOG.setLevel('CRITICAL')
 
 
-VTK9 = vtk.vtkVersion().GetVTKMajorVersion() >= 9
-
-
 invalid_input = TypeError('Invalid input.  Must be either a pyvista.PolyData\n' +
                           'object or vertex and face arrays')
 
 
-class TetGen(object):
+class TetGen:
     """Input, clean, and tetrahedralize surface meshes using
     TetGen
 
@@ -341,9 +338,9 @@ class TetGen(object):
         Notes
         -----
         There are many other options and the TetGen documentation
-        contains descritpions only for the switches of the original
+        contains descriptions only for the switches of the original
         C++ program.  This is the relationship between tetgen switches
-        and python optinal inputs:
+        and python optional inputs:
 
         - ``psc`` --> ``'-s'``
         - ``refine`` --> ``'-r'``
@@ -417,7 +414,7 @@ class TetGen(object):
         if verbose == 0:
             quiet = 1
 
-        # Call libary
+        # Call library
         plc = True  # always true
         try:
             self.node, self.elem = _tetgen.Tetrahedralize(self.v,


### PR DESCRIPTION
This PR removes the direct `import vtk`, thus avoiding importing the entire vtk library when using VTK>=9.

Also includes some minor spelling cleanup.﻿
