### PR TITLE
use latest build env

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v3
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.8.0
+        uses: pypa/cibuildwheel@v2.8.1
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Use latest build env:

> The macOS-10.15 environment is deprecated and will be removed on August 30th, 2022. For more details, see https://github.com/actions/virtual-environments/issues/5583
