### PR TITLE
Add support for numpy 2.0

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.20.0
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-14, macos-13]
 
     steps:
       - uses: actions/checkout@v4
@@ -76,7 +76,7 @@ jobs:
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
           files: |

--- a/README.rst
+++ b/README.rst
@@ -201,6 +201,12 @@ demonstrate how to accomplish this with TetGen and PyVista:
           for i in range(background_mesh.n_points):
               mtr_content.append(f"{target_size[i]:.8f}")
 
+          pv.save_meshio(f"{out_stem}.node", background_mesh)
+          mtr_file = f"{out_stem}.mtr"
+
+          with open(mtr_file, "w") as f:
+              f.write("\n".join(mtr_content))
+
       write_background_mesh(bg_mesh, 'bgmesh.b')
 
 3. **Use TetGen with the Background Mesh**:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=42",
     "wheel>=0.33.0",
     "cython>=3.0.0",
-    "oldest-supported-numpy"
+    "numpy>=2,<3",
 ]
 
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,14 +18,12 @@ filterwarnings = [
 
 [tool.cibuildwheel]
 archs = ["auto64"]  # 64-bit only
-skip = "pp* *musllinux* cp37-*"  # disable PyPy, musl-based wheels, and Python < 3.8
+skip = "pp* *musllinux* cp37-* cp38-*"  # disable PyPy and musl-based wheels and Python<3.9
 before-test = "pip install -r requirements_test.txt"
 test-command = "pytest {project}/tests"
 
 [tool.cibuildwheel.macos]
-# https://cibuildwheel.readthedocs.io/en/stable/faq/#apple-silicon
-archs = ["universal2"]
-test-skip = ["*_arm64", "*_universal2:arm64"]
+archs = ["native"]
 
 [tool.codespell]
 skip = '*.cxx,*.h,*.gif,*.png,*.jpg,*.js,*.html,*.doctree,*.ttf,*.woff,*.woff2,*.eot,*.mp4,*.inv,*.pickle,*.ipynb,flycheck*,./.git/*,./.hypothesis/*,*.yml,./doc/build/*,./doc/images/*,./dist/*,*~,.hypothesis*,./doc/source/examples/*,*cover,*.dat,*.mac,build,./docker/mapdl/v*,./factory/*,PKG-INFO,*.mypy_cache/*'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ filterwarnings = [
 
 [tool.cibuildwheel]
 archs = ["auto64"]  # 64-bit only
-skip = "pp* *musllinux* cp37-* cp38-*"  # disable PyPy and musl-based wheels and Python<3.9
+skip = "pp* *musllinux* cp37-* cp38-* cp313-*"  # Build CPython 3.9 - 3.12
 before-test = "pip install -r requirements_test.txt"
 test-command = "pytest {project}/tests"
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 """Setup for tetgen."""
+
 from io import open as io_open
 import os
 
@@ -36,11 +37,10 @@ setup(
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: GNU Affero General Public License v3",
         "Development Status :: 4 - Beta",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
     # Build cython modules
     ext_modules=cythonize(
@@ -60,7 +60,7 @@ setup(
             ),
         ],
     ),
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     keywords="TetGen",
-    install_requires=["numpy>1.16.0", "pyvista>=0.31.0"],
+    install_requires=["numpy>=2,<3", "pyvista>=0.31.0"],
 )


### PR DESCRIPTION
Resolve #68 by adding support for numpy 2.0 by building with numpy 2.0 and dropping Python 3.8 support.

Also, build native MacOS wheels.