### PR TITLE
Fix release step

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -66,6 +66,7 @@ jobs:
       url: https://pypi.org/p/tetgen
     permissions:
       id-token: write  # this permission is mandatory for trusted publishing
+      contents: write  # required to create a release
     steps:
       - uses: actions/download-artifact@v4
       - name: Flatten directory structure


### PR DESCRIPTION
Release step is failing to create a release:
https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions

Turns out we need to add `contents: write` to our release step permissions. See [Workflow syntax for GitHub Actions
](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions).